### PR TITLE
Add option to use unlimited AF key

### DIFF
--- a/src/lib/.defaultrc
+++ b/src/lib/.defaultrc
@@ -94,3 +94,7 @@ CONFIDENCE_LEVELS={'15':90,'25':80,'40':70,'50':60,'60':50}
 AUTOFOCUS_SEARCH_URL=https://autofocus.paloaltonetworks.com/api/v1.0/samples/search
 AUTOFOCUS_RESULTS_URL=https://autofocus.paloaltonetworks.com/api/v1.0/samples/results/
 AUTOFOCUS_TAG_URL=https://autofocus.paloaltonetworks.com/api/v1.0/tag/
+
+# Is the AutoFocus key you're using an unlimited key? If True, we will tag all domains,
+# including generic ones.
+AUTOFOCUS_KEY_IS_UNLIMITED=False

--- a/src/pandorica.py
+++ b/src/pandorica.py
@@ -40,8 +40,7 @@ def pandorica():
     # Download latest release notes and parse any that haven't been.
     download_then_parse_all()
 
-    # Ask AutoFocus about all unprocessed non-generic domains
-    # multiple times (in case of failure).
+    # Ask AutoFocus about domains multiple times (in case of failure).
     for _ in range(3):
         process_domains()
 


### PR DESCRIPTION
Set `AUTOFOCUS_KEY_IS_UNLIMITED=True` in your `.panrc` if your AutoFocus key is unlimited. Note that 'True' is a string and not a bool (which is a little confusing) because Python reads in all environment variables as strings.

You don't need to worry about setting this variable in Jenkins--just set it in the `.panrc` on the server. 

I've tested it on my local Elasticsearch instance, but I haven't actually used it at scale or with non-generic domains.

I also haven't used it with a real unlimited key. (Will it die when we ask for the number of AutoFocus points on an unlimited key? If it does, it breaks these fields out in the Safe code--probably none of my code will need modification.)